### PR TITLE
Handle unrecognized BGP option codes gracefully

### DIFF
--- a/bgp.go
+++ b/bgp.go
@@ -267,7 +267,7 @@ func (r *bgpPathAttributeReader) Next() (*BGPPathAttribute, error) {
 	case 35:
 		attr.Value = AS(valueBytes)
 	default:
-		return nil, fmt.Errorf("unknown BGP path attribute type code: %d", attr.TypeCode)
+		attr.Value = valueBytes
 	}
 
 	return attr, err


### PR DESCRIPTION
Hi,

I was able to use the `asnlookup` package for a network flow monitoring setup, so thank you for developing it.

When using MRT dumps from [RIPE](https://ris.ripe.net/docs/20_raw_data_mrt.html) I noticed there are still some BGP option codes which can't be parsed by `go-mrt` resulting in an error (e.g. `failed to parse MRT record: unknown MRT record type: 0`). To increase compatibility I think it would be beneficial to handle these parsing errors gracefully.

Best regards,
Sebastian